### PR TITLE
Removal of Base64 library, which is no longer needed.

### DIFF
--- a/BBAES/BBAES/Classes/BBAES.h
+++ b/BBAES/BBAES/Classes/BBAES.h
@@ -20,6 +20,7 @@ typedef NS_ENUM(NSUInteger, BBAESKeySize) {
 };
 
 typedef NS_ENUM(NSUInteger, BBAESEncryptionOptions) {
+    BBAESEncryptionOptionsNone = 0,
     BBAESEncryptionOptionsIncludeIV = 1 <<  0 // the IV is saved along with the ciphertext (the IV is stored as the first block of the encrypted data).
 };
 

--- a/BBAES/BBAES/Classes/BBAES.m
+++ b/BBAES/BBAES/Classes/BBAES.m
@@ -37,96 +37,6 @@ static NSData * SHA256Hash(NSData* data) {
 	return digest(data, CC_SHA256, CC_SHA256_DIGEST_LENGTH);
 }
 
-static NSData * dataFromBase64EncodedString(NSString* string) {
-	// Copyright (C) 2012 Charcoal Design (https://github.com/nicklockwood/Base64)
-    const char lookup[] =
-    {
-        99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99,
-        99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99,
-        99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 62, 99, 99, 99, 63,
-        52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 99, 99, 99, 99, 99, 99,
-        99,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 99, 99, 99, 99, 99,
-        99, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-        41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 99, 99, 99, 99, 99
-    };
-    
-    NSData *inputData = [string dataUsingEncoding:NSASCIIStringEncoding allowLossyConversion:YES];
-    long long inputLength = [inputData length];
-    const unsigned char *inputBytes = [inputData bytes];
-    
-    long long maxOutputLength = (inputLength / 4 + 1) * 3;
-    NSMutableData *outputData = [NSMutableData dataWithLength:(NSUInteger)maxOutputLength];
-    unsigned char *outputBytes = (unsigned char *)[outputData mutableBytes];
-	
-    int accumulator = 0;
-    long long outputLength = 0;
-    unsigned char accumulated[] = {0, 0, 0, 0};
-    for (long long i = 0; i < inputLength; i++) {
-        unsigned char decoded = lookup[inputBytes[i] & 0x7F];
-        if (decoded != 99) {
-            accumulated[accumulator] = decoded;
-            if (accumulator == 3) {
-                outputBytes[outputLength++] = (accumulated[0] << 2) | (accumulated[1] >> 4);
-                outputBytes[outputLength++] = (accumulated[1] << 4) | (accumulated[2] >> 2);
-                outputBytes[outputLength++] = (accumulated[2] << 6) | accumulated[3];
-            }
-            accumulator = (accumulator + 1) % 4;
-        }
-    }
-    
-    if (accumulator > 0) outputBytes[outputLength] = (accumulated[0] << 2) | (accumulated[1] >> 4);
-    if (accumulator > 1) outputBytes[++outputLength] = (accumulated[1] << 4) | (accumulated[2] >> 2);
-    if (accumulator > 2) outputLength++;
-    
-    outputData.length = (CFIndex)outputLength;
-    return outputLength? outputData: nil;
-}
-
-static NSString * base64EncodedStringFromData(NSData* data) {
-	// Copyright (C) 2012 Charcoal Design (https://github.com/nicklockwood/Base64)
-    const NSUInteger wrapWidth = 0;
-    const char lookup[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    
-    long long inputLength = [data length];
-    const unsigned char *inputBytes = [data bytes];
-    
-    long long maxOutputLength = (inputLength / 3 + 1) * 4;
-    maxOutputLength += wrapWidth? (maxOutputLength / wrapWidth) * 2: 0;
-    unsigned char *outputBytes = (unsigned char *)malloc((size_t)maxOutputLength);
-    
-    long long i;
-    long long outputLength = 0;
-    for (i = 0; i < inputLength - 2; i += 3) {
-        outputBytes[outputLength++] = lookup[(inputBytes[i] & 0xFC) >> 2];
-        outputBytes[outputLength++] = lookup[((inputBytes[i] & 0x03) << 4) | ((inputBytes[i + 1] & 0xF0) >> 4)];
-        outputBytes[outputLength++] = lookup[((inputBytes[i + 1] & 0x0F) << 2) | ((inputBytes[i + 2] & 0xC0) >> 6)];
-        outputBytes[outputLength++] = lookup[inputBytes[i + 2] & 0x3F];
-        
-        if (wrapWidth && (outputLength + 2) % (wrapWidth + 2) == 0) {
-            outputBytes[outputLength++] = '\r';
-            outputBytes[outputLength++] = '\n';
-        }
-    }
-    
-    if (i == inputLength - 2) {
-        outputBytes[outputLength++] = lookup[(inputBytes[i] & 0xFC) >> 2];
-        outputBytes[outputLength++] = lookup[((inputBytes[i] & 0x03) << 4) | ((inputBytes[i + 1] & 0xF0) >> 4)];
-        outputBytes[outputLength++] = lookup[(inputBytes[i + 1] & 0x0F) << 2];
-        outputBytes[outputLength++] =   '=';
-    }
-    else if (i == inputLength - 1) {
-        outputBytes[outputLength++] = lookup[(inputBytes[i] & 0xFC) >> 2];
-        outputBytes[outputLength++] = lookup[(inputBytes[i] & 0x03) << 4];
-        outputBytes[outputLength++] = '=';
-        outputBytes[outputLength++] = '=';
-    }
-    outputBytes = realloc(outputBytes, (size_t)outputLength);
-    NSString *result = [[NSString alloc] initWithBytesNoCopy:outputBytes length:(NSUInteger)outputLength encoding:NSASCIIStringEncoding freeWhenDone:YES];
-	
-    return (outputLength >= 4) ? result: nil;
-}
-
 static NSString * hexStringFromData(NSData* data){
 	NSUInteger capacity = data.length * 2;
 	NSMutableString *stringBuffer = [NSMutableString stringWithCapacity:capacity];
@@ -235,7 +145,7 @@ NSUInteger const BBAESSaltDefaultLength = 16; //recommandations suggest at least
 
 + (NSString *)encryptedStringFromData:(NSData *)data IV:(NSData *)iv key:(NSData *)key options:(BBAESEncryptionOptions)options {
 	NSData *encryptedData = [BBAES encryptedDataFromData:data IV:iv key:key options:options];
-	NSString *retValue = base64EncodedStringFromData(encryptedData);
+    NSString *retValue = [encryptedData base64EncodedStringWithOptions: 0];//base64EncodedStringFromData(encryptedData);
 	return retValue;
 }
 
@@ -261,7 +171,7 @@ NSUInteger const BBAESSaltDefaultLength = 16; //recommandations suggest at least
 }
 
 + (NSData *)decryptedDataFromString:(NSString *)string IV:(NSData *)iv key:(NSData *)key {
-	NSData *data = dataFromBase64EncodedString(string);
+    NSData *data = [[NSData alloc] initWithBase64EncodedString: string options: 0];
 	NSData *decryptedData = [BBAES decryptedDataFromData:data IV:iv key:key];
 	return decryptedData;
 }
@@ -270,7 +180,7 @@ NSUInteger const BBAESSaltDefaultLength = 16; //recommandations suggest at least
 
 + (NSString *)stringFromData:(NSData *)data encoding:(BBAESDataEncoding)encoding {
 	if (encoding == BBAESDataEncodingBase64) {
-		return base64EncodedStringFromData(data);
+		return [data base64EncodedStringWithOptions: 0];
 	}
 	else if (encoding == BBAESDataEncodingHex) {
 		return hexStringFromData(data);
@@ -281,7 +191,7 @@ NSUInteger const BBAESSaltDefaultLength = 16; //recommandations suggest at least
 
 + (NSData *)dataFromString:(NSString *)string encoding:(BBAESDataEncoding)encoding {
 	if (encoding == BBAESDataEncodingBase64) {
-		return dataFromBase64EncodedString(string);
+		return [[NSData alloc] initWithBase64EncodedString: string options: 0];
 	}
 	else if (encoding == BBAESDataEncodingHex) {
 		return dataFromHexString(string);

--- a/BBAES/BBAES/Classes/BBAES.m
+++ b/BBAES/BBAES/Classes/BBAES.m
@@ -145,7 +145,7 @@ NSUInteger const BBAESSaltDefaultLength = 16; //recommandations suggest at least
 
 + (NSString *)encryptedStringFromData:(NSData *)data IV:(NSData *)iv key:(NSData *)key options:(BBAESEncryptionOptions)options {
 	NSData *encryptedData = [BBAES encryptedDataFromData:data IV:iv key:key options:options];
-    NSString *retValue = [encryptedData base64EncodedStringWithOptions: 0];//base64EncodedStringFromData(encryptedData);
+    NSString *retValue = [encryptedData base64EncodedStringWithOptions: 0];
 	return retValue;
 }
 


### PR DESCRIPTION
Since iOS 7 and Mac OS X 10.9 the OS provides equivalent functionality.
